### PR TITLE
feat(arch): add Arch Linux packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,8 @@ Thumbs.db
 externals/
 prev/
 testing-api/
+
+# Archy Things
+packages/archlinux/src
+packages/archlinux/pkg
+packages/archlinux/tiny-request

--- a/packages/archlinux/PKGBUILD
+++ b/packages/archlinux/PKGBUILD
@@ -1,0 +1,49 @@
+# Maintainer: hikari <me@metantesan.com>
+pkgname=tiny-request
+_pkgname=tiny-request
+pkgver=1.0.4.r4.g7f0213d
+pkgrel=1
+pkgdesc=""
+arch=('x86_64')
+url="https://github.com/dexter-xD/TinyRequest.git"
+license=('MIT')
+depends=('glfw' 'curl' 'cjson' 'libgl' 'libx11' 'libxrandr' 'libxinerama' 'libxcursor' 'libxi')
+makedepends=('git' 'cmake' 'make' 'base-devel')
+source=("$pkgname::git+$url#branch=main")
+sha256sums=('SKIP')
+
+pkgver() {
+  cd "$_pkgname"
+  (set -o pipefail
+   git describe --long --tags 2>/dev/null | sed 's/^v//;s/\([^-]*-g\)/r\1/;s/-/./g' ||
+   printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)")
+}
+
+prepare() {
+  cd "$_pkgname"
+  sh ./scripts/fetch_dependencies.sh
+}
+
+build() {
+  cd "$_pkgname"
+  mkdir -p build
+  cd build
+  cmake ..
+  make
+}
+
+package() {
+  cd "$_pkgname"
+
+  # Install the binary we built
+  install -Dm755 "build/bin/tinyrequest" "$pkgdir/usr/bin/tinyrequest"
+
+  # Copy the share directory from the debian package structure
+  # This includes .desktop file, docs, and other assets
+  mkdir -p "$pkgdir/usr/share/"
+  cp -a debian/usr/share/* "$pkgdir/usr/share/"
+
+  # Install a high-resolution icon. The .desktop file specifies 'Icon=tinyrequest'.
+  # We will name our icon 'tinyrequest.png' and place it in the standard hicolor theme directory.
+  # install -Dm644 "debain/usr/share/icons/hicolor/256x256/apps/tinyrequest.png" "$pkgdir/usr/share/icons/hicolor/256x256/apps/tinyrequest.png"
+}

--- a/scripts/fetch_dependencies.sh
+++ b/scripts/fetch_dependencies.sh
@@ -94,10 +94,15 @@ echo "Detecting system distribution..."
 
 if command -v pacman >/dev/null 2>&1; then
     # Arch Linux
-    echo "Detected Arch Linux - installing dependencies with pacman..."
-    echo "Installing: glfw, curl, cjson, libgl, libx11, libxrandr, libxinerama, libxcursor, libxi"
-    sudo pacman -Sy --noconfirm glfw curl cjson libgl libx11 libxrandr libxinerama libxcursor libxi
-    echo "Arch Linux dependencies installed successfully!"
+    if [ -n "$BUILDDIR" ]; then
+        echo "Running inside makepkg on Arch Linux - skipping system dependency installation."
+        echo "Dependencies are managed by pacman via the PKGBUILD."
+    else
+        echo "Detected Arch Linux - installing dependencies with pacman..."
+        echo "Installing: glfw, curl, cjson, libgl, libx11, libxrandr, libxinerama, libxcursor, libxi"
+        sudo pacman -Sy --noconfirm glfw curl cjson libgl libx11 libxrandr libxinerama libxcursor libxi
+        echo "Arch Linux dependencies installed successfully!"
+    fi
     
 elif command -v apt >/dev/null 2>&1; then
     # Debian/Ubuntu


### PR DESCRIPTION
This pull request introduces packaging for Arch Linux, making it easier for users of Arch-based distributions to install and manage Tiny Request.

The following changes are included:

 * Arch Linux `PKGBUILD`: A PKGBUILD file has been added in the packages/archlinux directory. This file contains the necessary instructions to build and package Tiny Request from
   source.
 * Desktop Entry: A .desktop file is now included, allowing for better integration with desktop environments.
 * Dependency Script Update: The fetch_dependencies.sh script has been improved to detect when it's being run within the makepkg environment, preventing it from attempting to install
   system-level dependencies that are handled by pacman.
 * `.gitignore` Update: The .gitignore file has been updated to exclude the new package files from version control.

These changes have been tested and confirmed to produce a working Arch Linux package.
